### PR TITLE
Debug data not saving without errors

### DIFF
--- a/backup_bot/backup_bot.py
+++ b/backup_bot/backup_bot.py
@@ -166,7 +166,7 @@ def main():
     try:
         df = pd.read_csv(
             "temp_export.csv",
-            encoding='utf-8',
+            encoding='utf-8-sig',  # Remove BOM (Byte Order Mark) if present
             sep=None,  # Auto-detect delimiter
             on_bad_lines='warn',  # Warn about bad lines instead of failing
             engine='python',  # Use Python engine for more flexible parsing


### PR DESCRIPTION
The CSV export from Bear Blog contains a UTF-8 BOM (\ufeff) at the beginning of the file, which caused the first column to be named '\ufeffuid' instead of 'uid'. This resulted in KeyError exceptions for all 319 articles when trying to access row['uid'].

Changed encoding from 'utf-8' to 'utf-8-sig' which automatically strips the BOM during CSV parsing.