### PR TITLE
Add backup trigger on new social media post

### DIFF
--- a/.github/workflows/backup_bot.yml
+++ b/.github/workflows/backup_bot.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * 1'  # Every Monday at midnight UTC
   workflow_dispatch:  # Allows manual start
+  workflow_call:  # Allows being called from other workflows
 
 jobs:
   backup:

--- a/.github/workflows/social_bot.yml
+++ b/.github/workflows/social_bot.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      changes: ${{ steps.save_state.outputs.changes }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -33,10 +35,21 @@ jobs:
         run: python social_bot/social_bot.py
 
       - name: Save State
+        id: save_state
         run: |
           git config user.name "Bot"
           git config user.email "bot@github.com"
           git add social_bot/posted_articles.txt
           # "|| exit 0" prevents error if there are no changes to commit
-          git commit -m "Update posted articles [skip ci]" || exit 0
-          git push
+          if git commit -m "Update posted articles [skip ci]"; then
+            echo "changes=true" >> $GITHUB_OUTPUT
+            git push
+          else
+            echo "changes=false" >> $GITHUB_OUTPUT
+          fi
+
+  trigger-backup:
+    needs: build
+    if: needs.build.outputs.changes == 'true'
+    uses: ./.github/workflows/backup_bot.yml
+    secrets: inherit


### PR DESCRIPTION
- Enable workflow_call trigger for backup_bot.yml
- Extend social_bot.yml to trigger backup when new articles are posted
- Only runs backup if posted_articles.txt was actually modified