### PR TITLE
Investigate backup failure issue

### DIFF
--- a/backup_bot/requirements.txt
+++ b/backup_bot/requirements.txt
@@ -1,2 +1,3 @@
 pandas>=2.0.0
 requests>=2.31.0
+PyYAML>=6.0


### PR DESCRIPTION
The backup bot was failing with ModuleNotFoundError: No module named 'yaml' because PyYAML was imported in backup_bot.py but not listed in requirements.txt.