### PR TITLE
Fix article auto-save functionality

### DIFF
--- a/.github/workflows/social_bot.yml
+++ b/.github/workflows/social_bot.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           git config user.name "Bot"
           git config user.email "bot@github.com"
-          git add social_bot/posted_articles.txt
+          git add social_bot/posted_articles.txt social_bot/feed_cache.json
           # "|| exit 0" prevents error if there are no changes to commit
           if git commit -m "Update posted articles [skip ci]"; then
             echo "changes=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Include feed_cache.json in commits to preserve ETag/Last-Modified cache between workflow runs. This improves efficiency by preventing unnecessary RSS feed downloads.