### PR TITLE
Debug backup process failure and CSV issues

### DIFF
--- a/backup_bot/backup_bot.py
+++ b/backup_bot/backup_bot.py
@@ -426,15 +426,17 @@ def parse_csv(csv_path: Path) -> pd.DataFrame:
         if file_size < 100:
             raise ValueError(f"CSV file suspiciously small ({file_size} bytes)")
 
+        # Use C engine which handles multiline quoted fields correctly
+        # The Python engine has issues with multiline content in quoted fields
         df = pd.read_csv(
             csv_path,
             encoding='utf-8-sig',  # Remove BOM (Byte Order Mark) if present
-            on_bad_lines='warn',  # Warn about bad lines instead of failing
-            engine='python',  # Use Python engine for more flexible parsing
+            engine='c',  # C engine handles multiline quoted fields better
             sep=',',  # BearBlog uses comma-separated CSV
             quotechar='"',  # Standard quote character
             doublequote=True,  # Handle double quotes
-            skipinitialspace=True  # Skip spaces after delimiter
+            skipinitialspace=True,  # Skip spaces after delimiter
+            on_bad_lines='warn'  # Warn about bad lines instead of failing
         )
 
         logger.info(f"Parsed CSV: {len(df)} articles found")


### PR DESCRIPTION
Switch from Python to C engine in pandas read_csv. The Python engine incorrectly interprets newlines inside quoted fields as row separators, causing "unexpected end of data" errors. The C engine properly handles RFC-4180 compliant CSV with multiline quoted content.