### PR TITLE
Fix backup process running indefinitely

### DIFF
--- a/.github/workflows/backup_bot.yml
+++ b/.github/workflows/backup_bot.yml
@@ -27,12 +27,19 @@ jobs:
         run: pip install -r backup_bot/requirements.txt
 
       - name: Run Backup Bot
+        id: backup
         env:
           BEAR_COOKIE: ${{ secrets.BEAR_COOKIE }}
         run: python backup_bot/backup_bot.py
+        continue-on-error: true  # Continue to commit debug CSV even on failure
 
       - name: Commit and Push Blog Posts
+        if: always()  # Always run to commit debug CSV for inspection
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "Automated blog backup [skip ci]"
-          file_pattern: 'blog_posts/** backup_bot/processed_articles.txt'
+          file_pattern: 'blog_posts/** backup_bot/processed_articles.txt backup_bot/last_export.csv'
+
+      - name: Fail if backup failed
+        if: steps.backup.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
- Use single iterator for streaming download to avoid truncation issue
- Save debug copy of CSV to backup_bot/last_export.csv for inspection
- Update workflow to commit debug CSV even on failure
- This allows diagnosing CSV parsing issues by inspecting the actual downloaded file