### PR TITLE
Fix missing image download for article

### DIFF
--- a/backup_bot/backup_bot.py
+++ b/backup_bot/backup_bot.py
@@ -33,6 +33,7 @@ MAX_WORKERS = 5  # Concurrent image downloads
 # Security: Allowed image domains
 ALLOWED_IMAGE_DOMAINS = {
     'bearblog.dev',
+    'digitaloceanspaces.com',  # Bear Blog CDN (bear-images.sfo2.cdn.digitaloceanspaces.com)
     'imgur.com',
     'i.imgur.com',
     'cloudinary.com',


### PR DESCRIPTION
Images hosted on bear-images.sfo2.cdn.digitaloceanspaces.com were not being downloaded because digitaloceanspaces.com was missing from the ALLOWED_IMAGE_DOMAINS whitelist.