### PR TITLE
Fix backup job failure after article updates

### DIFF
--- a/.github/workflows/backup_bot.yml
+++ b/.github/workflows/backup_bot.yml
@@ -49,8 +49,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: ${{ github.event_name == 'workflow_dispatch' && 'Manual blog backup' || github.event_name == 'schedule' && 'Scheduled blog backup' || 'Automatic blog backup' }}
-          # Note: last_export.csv is only saved if save_debug_csv is enabled in config.yaml
-          file_pattern: 'blog-backup/** bots/backup_bot/processed_articles.txt bots/backup_bot/last_export.csv'
+          file_pattern: 'blog-backup/** bots/backup_bot/processed_articles.txt'
 
       - name: Fail if backup failed
         if: steps.backup.outcome == 'failure'


### PR DESCRIPTION
The git-auto-commit-action was failing because it tried to add bots/backup_bot/last_export.csv which doesn't exist (only created when save_debug_csv is enabled).