### PR TITLE
Add max_article_age_days setting to prevent re-posting old articles

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,3 +38,9 @@ backup:
 social:
   # Your Mastodon instance URL
   mastodon_instance: "https://mastodon.social"
+
+  # Maximum age of articles (in days) that will be automatically posted.
+  # Articles older than this will be skipped, even if their URL is new.
+  # This prevents accidental re-posts when editing old articles (e.g., changing URLs).
+  # Set to 0 or remove to disable this check (post all articles regardless of age).
+  max_article_age_days: 7

--- a/docs/SOCIAL_BOT.md
+++ b/docs/SOCIAL_BOT.md
@@ -22,7 +22,13 @@ The Social Bot automatically posts new blog entries from your RSS feeds to Blues
 ```yaml
 social:
   mastodon_instance: "https://mastodon.social"
+  max_article_age_days: 7  # Optional: Skip articles older than X days
 ```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `mastodon_instance` | — | Your Mastodon instance URL |
+| `max_article_age_days` | `0` (disabled) | Skip articles older than X days (see [Article Age Limit](#article-age-limit)) |
 
 ### Feed Config (`bots/social_bot/config.json`)
 
@@ -146,6 +152,26 @@ Configure these in **Settings → Secrets → Actions**:
 
 ### Efficiency
 - Tracks posted articles to prevent duplicates
+
+### Article Age Limit
+
+When you edit an old article (e.g., change its URL or title), it might appear as "new" to the bot since the URL isn't in the posted articles list. To prevent accidentally re-posting old content, you can set a maximum article age:
+
+```yaml
+social:
+  max_article_age_days: 7
+```
+
+**How it works:**
+- The bot checks the article's `published` date from the RSS feed
+- Articles older than the configured limit are skipped, even if they haven't been posted before
+- This is particularly useful when migrating content or editing old articles
+- Set to `0` or remove the setting to disable this check
+
+**Example log output:**
+```
+Skipping old article (14 days old, max 7): My Old Blog Post
+```
 
 ### Automatic Issue for Unmatched Articles
 When a new article doesn't match any posting configuration, the bot:


### PR DESCRIPTION
When editing old articles (e.g., changing URLs), they would appear as
"new" to the bot and get re-posted. This adds a configurable age limit
that skips articles older than X days based on their published date.

- Add max_article_age_days setting to config.yaml (default: 7 days)
- Add get_article_age_days() and is_article_too_old() functions
- Skip old articles in the main processing loop with info logging
- Document the feature in docs/SOCIAL_BOT.md