### PR TITLE
Debug job failure with runner logs

### DIFF
--- a/.github/workflows/social_bot.yml
+++ b/.github/workflows/social_bot.yml
@@ -108,6 +108,8 @@ jobs:
           # "|| exit 0" prevents error if there are no changes to commit
           if git commit -m "Update posted articles and feed cache"; then
             echo "changes=true" >> $GITHUB_OUTPUT
+            # Pull latest changes before pushing to avoid conflicts with parallel workflows
+            git pull --rebase origin main
             git push
           else
             echo "changes=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Add git pull --rebase before push to handle cases where another workflow (e.g., backup_bot) has pushed changes while this workflow was running. This prevents "rejected - fetch first" errors.