### PR TITLE
Investigate missing photo post suggestion

### DIFF
--- a/bots/social_bot/feed_cache.json
+++ b/bots/social_bot/feed_cache.json
@@ -1,7 +1,7 @@
 {
   "https://fischr.org/feed?q=fotos": {
     "etag": "",
-    "last-modified": "Fri, 02 Jan 2026 11:52:37 GMT"
+    "last-modified": ""
   },
   "https://fischr.org/feed?q=popcornfieber": {
     "etag": "",
@@ -9,6 +9,6 @@
   },
   "https://fischr.org/feed/": {
     "etag": "",
-    "last-modified": "Fri, 02 Jan 2026 11:52:37 GMT"
+    "last-modified": ""
   }
 }


### PR DESCRIPTION
The cache was being updated when new entries were found, but BEFORE they were actually posted. If posting failed, the cache remained updated, causing the feed to be skipped on subsequent runs.

Now the cache is only updated AFTER all entries from a feed have been successfully processed (posted, skipped as too old, or unmatched). This ensures feeds with failed posts will be re-fetched on the next run.

Also reset the fotos and main feed cache to allow re-processing of the missed "Mein bestes Foto 2025" article.