### PR TITLE
Add automatic Internet Archive integration for new articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Hey and welcome 👋🏼 This is the powerhouse behind my [Bear Blog](https://be
 
 - **posts the article to Mastodon and Bluesky**, with an individual template based on the content
 - **backs up everything** as Markdown files with images right here in this repo
-- and **pings search engines** for faster indexing.
+- **pings search engines** for faster indexing
+- and **archives URLs to the Internet Archive** for long-term preservation.
 
 ## Project Structure
 

--- a/bots/social_bot/social_bot.py
+++ b/bots/social_bot/social_bot.py
@@ -405,6 +405,31 @@ def submit_to_indexnow(url: str) -> None:
         logger.warning(f"IndexNow request failed: {e}")
 
 
+def submit_to_web_archive(url: str) -> None:
+    """
+    Submit the URL to the Internet Archive (web.archive.org) for archival.
+    Creates a permanent snapshot of the content using the Save Page Now API.
+    """
+    # Check if web archive integration is enabled
+    if not CONFIG.get('web_archive', {}).get('enabled', False):
+        return
+
+    try:
+        # Internet Archive Save Page Now API endpoint
+        # Using the simple GET method which doesn't require authentication
+        archive_url = f"https://web.archive.org/save/{url}"
+
+        response = session.get(
+            archive_url,
+            timeout=REQUEST_TIMEOUT,
+            allow_redirects=True
+        )
+        response.raise_for_status()
+        logger.info(f"Web Archive submission success for {url}")
+    except Exception as e:
+        logger.warning(f"Web Archive submission failed for {url}: {e}")
+
+
 BLUESKY_MAX_LENGTH = 300  # Bluesky's limit in graphemes
 
 
@@ -796,6 +821,7 @@ def post_entry(entry: Any, cfg: Dict[str, Any], posted_cache: Set[str]) -> bool:
         # Save the mapping from article URL to social media post URLs
         save_social_mapping(entry.link, mastodon_url=mastodon_url, bluesky_url=bluesky_url)
         submit_to_indexnow(entry.link)
+        submit_to_web_archive(entry.link)
         mark_as_posted(entry.link)
         posted_cache.add(entry.link)
 

--- a/config.yaml
+++ b/config.yaml
@@ -44,3 +44,8 @@ social:
   # This prevents accidental re-posts when editing old articles (e.g., changing URLs).
   # Set to 0 or remove to disable this check (post all articles regardless of age).
   max_article_age_days: 3
+
+web_archive:
+  # Automatically submit new article URLs to the Internet Archive (web.archive.org)
+  # This creates a permanent snapshot of your content for long-term preservation
+  enabled: true

--- a/docs/SOCIAL_BOT.md
+++ b/docs/SOCIAL_BOT.md
@@ -12,6 +12,7 @@ The Social Bot automatically posts new blog entries from your RSS feeds to Blues
 4. Formats posts using customizable templates
 5. Posts to Bluesky and/or Mastodon with rich text and link cards
 6. Submits URLs to search engines via IndexNow
+7. Archives URLs to the Internet Archive for long-term preservation (optional)
 
 ---
 
@@ -23,12 +24,16 @@ The Social Bot automatically posts new blog entries from your RSS feeds to Blues
 social:
   mastodon_instance: "https://mastodon.social"
   max_article_age_days: 7  # Optional: Skip articles older than X days
+
+web_archive:
+  enabled: true  # Optional: Archive URLs to web.archive.org
 ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `mastodon_instance` | — | Your Mastodon instance URL |
 | `max_article_age_days` | `0` (disabled) | Skip articles older than X days (see [Article Age Limit](#article-age-limit)) |
+| `web_archive.enabled` | `false` | Automatically submit URLs to Internet Archive (see [Web Archive Integration](#web-archive-integration)) |
 
 ### Feed Config (`bots/social_bot/config.json`)
 
@@ -172,6 +177,27 @@ social:
 ```
 Skipping old article (14 days old, max 7): My Old Blog Post
 ```
+
+### Web Archive Integration
+
+When enabled in `config.yaml`, the bot automatically submits new article URLs to the [Internet Archive](https://web.archive.org) for permanent preservation:
+
+```yaml
+web_archive:
+  enabled: true  # Set to false to disable
+```
+
+**How it works:**
+- After successfully posting to social media, the URL is submitted to web.archive.org
+- Creates a permanent snapshot of your content
+- No authentication required
+- Runs asynchronously (doesn't block posting if Archive is slow)
+
+**Benefits:**
+- 📚 Permanent preservation even if your site goes down
+- 📖 Historical record of your content
+- 🔗 Citable archived versions for researchers
+- 💾 Additional backup layer
 
 ### Automatic Issue for Unmatched Articles
 When a new article doesn't match any posting configuration, the bot:


### PR DESCRIPTION
This commit implements automatic submission of new article URLs to the Internet Archive (web.archive.org) for long-term preservation.

Changes:
- Added web_archive config section in config.yaml with enabled flag
- Implemented submit_to_web_archive() function using Save Page Now API
- Integrated Web Archive submission into post_entry() workflow
- Updated README to mention the archival feature
- Updated SOCIAL_BOT.md with comprehensive documentation

When enabled, newly posted articles are automatically archived to web.archive.org, creating permanent snapshots of the content. This complements the existing IndexNow search engine integration and ensures content is preserved for the long term.

The feature can be disabled by setting web_archive.enabled to false in config.yaml.