### PR TITLE
Fix bot generating frontend errors constantly

### DIFF
--- a/.github/workflows/social_bot.yml
+++ b/.github/workflows/social_bot.yml
@@ -214,7 +214,14 @@ jobs:
         run: |
           git config user.name "Bot"
           git config user.email "bot@github.com"
-          git add bots/social_bot/posted_articles.txt bots/social_bot/feed_cache.json bots/social_bot/retry_queue.json mappings.json
+
+          # Add files that exist (some may not exist if there's nothing to track)
+          for file in bots/social_bot/posted_articles.txt bots/social_bot/feed_cache.json bots/social_bot/retry_queue.json mappings.json; do
+            if [ -f "$file" ]; then
+              git add "$file"
+            fi
+          done
+
           # "|| exit 0" prevents error if there are no changes to commit
           if git commit -m "Update posted articles and feed cache"; then
             echo "changes=true" >> $GITHUB_OUTPUT

--- a/bots/social_bot/process_retry_queue.py
+++ b/bots/social_bot/process_retry_queue.py
@@ -10,11 +10,12 @@ import sys
 import logging
 from pathlib import Path
 
-# Add parent directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
+# Add directories to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))  # For shared module
+sys.path.insert(0, str(Path(__file__).parent))  # For local modules
 
-from social_bot.retry_queue import RetryQueue
-from social_bot.social_bot import (
+from retry_queue import RetryQueue
+from social_bot import (
     post_to_bluesky,
     post_to_mastodon,
     get_first_image_data,


### PR DESCRIPTION
Fixes two critical issues causing GitHub Actions failures:

1. ModuleNotFoundError in process_retry_queue.py
   - The script was trying to import 'social_bot.retry_queue' as a package
   - Changed imports to directly reference modules by adding the current directory to sys.path
   - Now uses 'from retry_queue import RetryQueue' instead of package-style imports

2. Git add failure for non-existent retry_queue.json
   - The workflow was trying to add retry_queue.json unconditionally
   - This file only exists when there are actual retry entries
   - Changed to only add files that exist using a conditional loop

Both errors are now resolved and the bot should run without failures.