### PR TITLE
Add webmentions collection feature

### DIFF
--- a/.github/workflows/fetch-webmentions.yml
+++ b/.github/workflows/fetch-webmentions.yml
@@ -1,0 +1,70 @@
+name: Fetch Webmentions
+
+run-name: Fetch blog webmentions from webmention.io
+
+on:
+  schedule:
+    - cron: '0 */6 * * *' # Runs every 6 hours
+  workflow_dispatch: # Allows manual trigger
+
+# Ensure only one instance runs at a time to prevent data conflicts
+concurrency:
+  group: webmentions-fetch
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  fetch-webmentions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show Trigger Info
+        run: |
+          echo "🔗 Fetching webmentions from webmention.io"
+          echo "📅 Triggered by: ${{ github.event_name }}"
+          echo "⏰ Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Dependencies
+        run: |
+          pip install requests PyYAML
+
+      - name: Fetch Webmentions
+        env:
+          WEBMENTION_IO_TOKEN: ${{ secrets.WEBMENTION_IO_TOKEN }}
+          BEARBLOG_DOMAIN: ${{ secrets.BEARBLOG_DOMAIN }}
+        run: |
+          echo "Fetching webmentions for domain: $BEARBLOG_DOMAIN"
+          python bots/webmentions/fetch_webmentions.py
+
+      - name: Commit Webmentions Data
+        run: |
+          git config user.name "Webmentions Bot"
+          git config user.email "bot@github.com"
+
+          # Check if webmentions.json exists and has changes
+          if [ -f "webmentions.json" ]; then
+            git add webmentions.json
+
+            # Commit if there are changes
+            if git diff --staged --quiet; then
+              echo "No new webmentions to commit"
+            else
+              echo "New webmentions found, committing..."
+              git commit -m "Update webmentions data"
+
+              # Pull latest changes before pushing to avoid conflicts
+              git pull --rebase origin ${{ github.ref_name }}
+              git push
+            fi
+          else
+            echo "No webmentions.json file generated"
+          fi

--- a/README.md
+++ b/README.md
@@ -5,17 +5,20 @@ Hey and welcome 👋🏼 This is the powerhouse behind my [Bear Blog](https://be
 - **posts the article to Mastodon and Bluesky**, with an individual template based on the content
 - **backs up everything** as Markdown files with images right here in this repo
 - **pings search engines** for faster indexing
-- and **archives URLs to the Internet Archive** for long-term preservation.
+- **archives URLs to the Internet Archive** for long-term preservation
+- and **collects webmentions** from other blogs linking to your articles.
 
 ## Project Structure
 
 ```
 ├── config.yaml              # Central configuration
 ├── mappings.json            # Article → Social post URL mappings (auto-generated)
+├── webmentions.json         # Blog webmentions collection (auto-generated)
 ├── bots/
 │   ├── social_bot/          # Social media posting bot
 │   │   └── config.json      # Feed & template config
-│   └── backup_bot/          # Bear Blog backup bot
+│   ├── backup_bot/          # Bear Blog backup bot
+│   └── webmentions/         # Webmentions collection bot
 ├── blog-backup/             # Archived posts (auto-generated)
 └── docs/                    # Documentation
 ```
@@ -106,6 +109,39 @@ web_archive:
 - Creates a permanent snapshot of your content
 - Runs asynchronously (doesn't block posting)
 - No authentication required
+
+---
+
+### 🔗 Webmentions Collection
+
+Automatically collects webmentions from traditional blog posts that link to your articles using [webmention.io](https://webmention.io).
+
+**What are webmentions:**
+Webmentions are the modern web's way of tracking who links to your content - think of them as backlinks or pingbacks that follow the W3C standard.
+
+**How it works:**
+- Fetches mentions from webmention.io API every 6 hours
+- **Filters out social media** (Mastodon, Bluesky, Twitter) - those are already in `mappings.json`
+- Stores only traditional blog mentions in `webmentions.json`
+- Incremental updates (only fetches new mentions)
+
+**Setup:**
+1. Sign up at [webmention.io](https://webmention.io) with your domain
+2. Add the webmention endpoint to your site's HTML `<head>`
+3. Add GitHub secrets: `WEBMENTION_IO_TOKEN` and `BEARBLOG_DOMAIN`
+4. The workflow runs automatically every 6 hours
+
+**Configuration:**
+```yaml
+webmentions:
+  enabled: true
+  excluded_domains:
+    - mastodon.social  # Already tracked in mappings.json
+    - bsky.app          # Already tracked in mappings.json
+    # Add more as needed
+```
+
+→ [Full Documentation](bots/webmentions/README.md)
 
 ---
 

--- a/bots/webmentions/README.md
+++ b/bots/webmentions/README.md
@@ -1,0 +1,178 @@
+# Webmentions Collection Bot
+
+This bot collects webmentions from traditional blog posts linking to your BearBlog articles using the [webmention.io](https://webmention.io) service.
+
+## What are Webmentions?
+
+Webmentions are a W3C standard protocol that allows one website to notify another that it has been linked to or mentioned. Think of them as "backlinks" or "pingbacks" for the modern web.
+
+## Key Features
+
+- **Blog-Only Collection**: Tracks only traditional blog webmentions
+- **Social Media Filtering**: Automatically excludes social media platforms (Mastodon, Bluesky, Twitter, etc.) since those are already tracked in `mappings.json` by the social bot
+- **Incremental Updates**: Only fetches new mentions since the last run
+- **Thread-Safe**: Uses file locking to prevent data corruption
+- **Automated**: Runs every 6 hours via GitHub Actions
+
+## Setup Instructions
+
+### 1. Set Up webmention.io Account
+
+1. Go to [webmention.io](https://webmention.io/)
+2. Sign in with your domain
+3. Get your API token from the dashboard
+4. Add the following to your website's HTML `<head>` section:
+
+```html
+<link rel="webmention" href="https://webmention.io/YOUR-DOMAIN/webmention" />
+<link rel="pingback" href="https://webmention.io/YOUR-DOMAIN/xmlrpc" />
+```
+
+Replace `YOUR-DOMAIN` with your actual domain (e.g., `fischr.org`).
+
+### 2. Configure GitHub Secrets
+
+Add the following secrets to your GitHub repository:
+
+1. Go to your repository **Settings** → **Secrets and variables** → **Actions**
+2. Add these secrets:
+   - `WEBMENTION_IO_TOKEN`: Your API token from webmention.io dashboard
+   - `BEARBLOG_DOMAIN`: Your BearBlog domain (e.g., `fischr.org`)
+
+### 3. Enable the Workflow
+
+The workflow is automatically enabled once you merge this feature branch. It will:
+- Run every 6 hours automatically
+- Can be triggered manually from the Actions tab
+
+## How It Works
+
+### Data Flow
+
+1. **Fetch**: Retrieves mentions from webmention.io API for your domain
+2. **Filter**: Excludes social media sources (already tracked elsewhere)
+3. **Process**: Organizes mentions by target URL
+4. **Store**: Saves to `webmentions.json` in the repository root
+5. **Commit**: Automatically commits changes to the repository
+
+### Output Format
+
+The `webmentions.json` file is structured as follows:
+
+```json
+{
+  "https://fischr.org/article-url/": {
+    "target": "https://fischr.org/article-url/",
+    "mentions": [
+      {
+        "source": "https://example-blog.com/post-linking-to-you/",
+        "type": "mention",
+        "published": "2026-01-08T12:00:00Z",
+        "author": {
+          "name": "Jane Blogger",
+          "url": "https://example-blog.com/"
+        },
+        "title": "Great article about...",
+        "content": "I found this interesting article...",
+        "fetched_at": "2026-01-08T14:30:00Z"
+      }
+    ]
+  }
+}
+```
+
+### Social Media Filtering
+
+The bot automatically excludes mentions from:
+- Mastodon instances (including custom instances)
+- Bluesky (bsky.app)
+- Twitter/X
+- Facebook, Instagram, Threads
+- LinkedIn
+
+These are excluded because:
+1. They're already tracked in `mappings.json` by the social bot
+2. They're not traditional blog webmentions
+3. This prevents duplicate tracking
+
+## Configuration
+
+Edit `config.yaml` to customize the webmentions settings:
+
+```yaml
+webmentions:
+  enabled: true
+  excluded_domains:
+    - mastodon.social
+    - bsky.app
+    # Add more domains as needed
+```
+
+## Manual Triggering
+
+You can manually trigger the webmentions fetch:
+
+1. Go to **Actions** tab in your repository
+2. Select **Fetch Webmentions** workflow
+3. Click **Run workflow** button
+
+## Troubleshooting
+
+### No mentions appearing?
+
+1. **Check webmention.io setup**: Verify the `<link>` tags are in your website's HTML
+2. **Verify API token**: Make sure `WEBMENTION_IO_TOKEN` secret is set correctly
+3. **Check domain**: Ensure `BEARBLOG_DOMAIN` matches your webmention.io account
+4. **Wait for mentions**: Other sites need to send webmentions to your endpoint first
+
+### Workflow failing?
+
+1. Check the Actions tab for error logs
+2. Verify both secrets are set correctly
+3. Ensure webmention.io service is accessible
+
+### Social media mentions still appearing?
+
+If you see social media mentions that shouldn't be there:
+1. Edit `config.yaml` and add the domain to `excluded_domains`
+2. Or edit `bots/webmentions/fetch_webmentions.py` to add it to `EXCLUDED_SOCIAL_DOMAINS`
+
+## File Structure
+
+```
+bots/webmentions/
+├── README.md                    # This file
+└── fetch_webmentions.py         # Main webmentions fetcher script
+
+.github/workflows/
+└── fetch-webmentions.yml        # GitHub Actions workflow
+
+webmentions.json                 # Output file (at repository root)
+```
+
+## Dependencies
+
+- `requests`: HTTP requests to webmention.io API
+- `PyYAML`: Configuration file parsing
+- Shared utilities from `bots/shared.py`
+
+## Development
+
+To test locally:
+
+```bash
+export WEBMENTION_IO_TOKEN="your-token"
+export BEARBLOG_DOMAIN="your-domain.com"
+python bots/webmentions/fetch_webmentions.py
+```
+
+## Related Features
+
+- **Social Bot**: Tracks Mastodon and Bluesky mentions in `mappings.json`
+- **Backup Bot**: Archives blog content for preservation
+
+## Resources
+
+- [webmention.io](https://webmention.io/) - Service homepage
+- [W3C Webmention Spec](https://www.w3.org/TR/webmention/) - Technical specification
+- [IndieWeb Wiki](https://indieweb.org/Webmention) - Community documentation

--- a/bots/webmentions/fetch_webmentions.py
+++ b/bots/webmentions/fetch_webmentions.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""
+Fetch webmentions from webmention.io and store blog-only mentions.
+Excludes social media platforms (Mastodon, Bluesky) as they're already tracked in mappings.json.
+"""
+
+import os
+import sys
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Set
+from urllib.parse import urlparse
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from shared import (
+    logger,
+    load_config,
+    FileLock,
+    BotException
+)
+
+# Configuration
+WEBMENTIONS_FILE = Path(__file__).parent.parent.parent / "webmentions.json"
+WEBMENTION_IO_API = "https://webmention.io/api/mentions.jf2"
+
+# Social media domains to exclude (already tracked in mappings.json)
+EXCLUDED_SOCIAL_DOMAINS = {
+    'mastodon.social',
+    'bsky.app',
+    'twitter.com',
+    'x.com',
+    'threads.net',
+    'linkedin.com',
+    'facebook.com',
+    'instagram.com',
+    # Add other Mastodon instances
+    'fosstodon.org',
+    'hachyderm.io',
+    'mas.to',
+    'mstdn.social',
+    'infosec.exchange',
+}
+
+
+def is_social_media_source(source_url: str) -> bool:
+    """
+    Check if the source URL is from a social media platform.
+
+    Args:
+        source_url: The URL to check
+
+    Returns:
+        True if from social media, False otherwise
+    """
+    try:
+        parsed = urlparse(source_url)
+        domain = parsed.netloc.lower()
+
+        # Remove 'www.' prefix
+        if domain.startswith('www.'):
+            domain = domain[4:]
+
+        # Check against excluded domains
+        if domain in EXCLUDED_SOCIAL_DOMAINS:
+            return True
+
+        # Check for Mastodon instances (contain 'mastodon' in domain)
+        if 'mastodon' in domain:
+            return True
+
+        # Check for Bluesky posts (bsky.app)
+        if 'bsky.app' in domain:
+            return True
+
+        return False
+    except Exception as e:
+        logger.warning(f"Error parsing URL {source_url}: {e}")
+        return False
+
+
+def fetch_webmentions(domain: str, token: str, since: str = None) -> List[Dict]:
+    """
+    Fetch webmentions from webmention.io API.
+
+    Args:
+        domain: The target domain to fetch mentions for
+        token: webmention.io API token
+        since: Optional ISO timestamp to fetch mentions since
+
+    Returns:
+        List of webmention objects
+    """
+    params = {
+        'target': f'https://{domain}/',
+        'token': token,
+        'per-page': 100  # Max allowed by webmention.io
+    }
+
+    if since:
+        params['since'] = since
+
+    try:
+        import requests
+        response = requests.get(WEBMENTION_IO_API, params=params, timeout=30)
+        response.raise_for_status()
+
+        data = response.json()
+        mentions = data.get('children', [])
+
+        logger.info(f"Fetched {len(mentions)} total mentions from webmention.io")
+        return mentions
+
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Failed to fetch webmentions: {e}")
+        raise BotException(f"Webmention fetch failed: {e}")
+
+
+def filter_blog_mentions(mentions: List[Dict]) -> List[Dict]:
+    """
+    Filter mentions to include only blog posts (exclude social media).
+
+    Args:
+        mentions: List of webmention objects
+
+    Returns:
+        Filtered list containing only blog mentions
+    """
+    blog_mentions = []
+    excluded_count = 0
+
+    for mention in mentions:
+        # Get source URL
+        source_url = mention.get('url', '')
+
+        if not source_url:
+            logger.debug("Skipping mention without source URL")
+            continue
+
+        # Check if it's from social media
+        if is_social_media_source(source_url):
+            excluded_count += 1
+            logger.debug(f"Excluding social media mention from: {source_url}")
+            continue
+
+        # This is a blog mention, keep it
+        blog_mentions.append(mention)
+
+    logger.info(f"Filtered to {len(blog_mentions)} blog mentions (excluded {excluded_count} social media)")
+    return blog_mentions
+
+
+def load_existing_webmentions() -> Dict:
+    """
+    Load existing webmentions from file.
+
+    Returns:
+        Dictionary of existing webmentions by target URL
+    """
+    if not WEBMENTIONS_FILE.exists():
+        logger.info("No existing webmentions file found, starting fresh")
+        return {}
+
+    try:
+        with FileLock(WEBMENTIONS_FILE):
+            with open(WEBMENTIONS_FILE, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+                logger.info(f"Loaded existing webmentions for {len(data)} target URLs")
+                return data
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse existing webmentions: {e}")
+        return {}
+    except Exception as e:
+        logger.error(f"Error loading webmentions: {e}")
+        return {}
+
+
+def save_webmentions(webmentions: Dict) -> None:
+    """
+    Save webmentions to file with file locking.
+
+    Args:
+        webmentions: Dictionary of webmentions to save
+    """
+    try:
+        # Ensure parent directory exists
+        WEBMENTIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+        with FileLock(WEBMENTIONS_FILE):
+            with open(WEBMENTIONS_FILE, 'w', encoding='utf-8') as f:
+                json.dump(webmentions, f, indent=2, ensure_ascii=False)
+
+        logger.info(f"Saved webmentions to {WEBMENTIONS_FILE}")
+    except Exception as e:
+        logger.error(f"Failed to save webmentions: {e}")
+        raise BotException(f"Failed to save webmentions: {e}")
+
+
+def process_mentions(mentions: List[Dict], existing_webmentions: Dict) -> Dict:
+    """
+    Process new mentions and merge with existing data.
+
+    Args:
+        mentions: List of new mentions from API
+        existing_webmentions: Existing webmentions data
+
+    Returns:
+        Updated webmentions dictionary
+    """
+    new_count = 0
+    updated_count = 0
+
+    for mention in mentions:
+        # Extract relevant fields
+        source_url = mention.get('url', '')
+        target_url = mention.get('wm-target', '')
+        mention_type = mention.get('wm-property', 'mention')
+        published = mention.get('published', mention.get('wm-received', ''))
+
+        # Author information
+        author = mention.get('author', {})
+        author_name = author.get('name', 'Unknown')
+        author_url = author.get('url', '')
+
+        # Content
+        content_obj = mention.get('content', {})
+        if isinstance(content_obj, dict):
+            content = content_obj.get('text', content_obj.get('html', ''))
+        else:
+            content = str(content_obj) if content_obj else ''
+
+        # Summary/title
+        summary = mention.get('summary', mention.get('name', ''))
+
+        if not source_url or not target_url:
+            logger.warning("Skipping mention with missing source or target URL")
+            continue
+
+        # Initialize target URL in data if not exists
+        if target_url not in existing_webmentions:
+            existing_webmentions[target_url] = {
+                'target': target_url,
+                'mentions': []
+            }
+
+        # Check if this mention already exists (by source URL)
+        existing_sources = {m.get('source') for m in existing_webmentions[target_url]['mentions']}
+
+        if source_url not in existing_sources:
+            # New mention
+            existing_webmentions[target_url]['mentions'].append({
+                'source': source_url,
+                'type': mention_type,
+                'published': published,
+                'author': {
+                    'name': author_name,
+                    'url': author_url
+                },
+                'title': summary,
+                'content': content[:500] if content else '',  # Truncate long content
+                'fetched_at': datetime.now().isoformat()
+            })
+            new_count += 1
+            logger.info(f"New webmention: {source_url} -> {target_url}")
+        else:
+            # Update existing mention if needed
+            updated_count += 1
+            logger.debug(f"Mention already exists: {source_url}")
+
+    logger.info(f"Processed {new_count} new mentions, {updated_count} already existed")
+    return existing_webmentions
+
+
+def get_last_fetch_time(existing_webmentions: Dict) -> str:
+    """
+    Get the timestamp of the last fetch to use as 'since' parameter.
+
+    Args:
+        existing_webmentions: Existing webmentions data
+
+    Returns:
+        ISO timestamp string or None
+    """
+    timestamps = []
+
+    for target_data in existing_webmentions.values():
+        for mention in target_data.get('mentions', []):
+            fetched_at = mention.get('fetched_at')
+            if fetched_at:
+                timestamps.append(fetched_at)
+
+    if timestamps:
+        # Return the most recent timestamp
+        latest = max(timestamps)
+        logger.info(f"Last fetch time: {latest}")
+        return latest
+
+    return None
+
+
+def main():
+    """Main entry point for webmentions fetcher."""
+    logger.info("=" * 60)
+    logger.info("Starting webmentions fetch")
+    logger.info("=" * 60)
+
+    # Get configuration
+    config = load_config()
+
+    # Get secrets from environment
+    token = os.environ.get('WEBMENTION_IO_TOKEN')
+    domain = os.environ.get('BEARBLOG_DOMAIN')
+
+    if not token:
+        logger.error("WEBMENTION_IO_TOKEN environment variable not set")
+        sys.exit(1)
+
+    if not domain:
+        logger.error("BEARBLOG_DOMAIN environment variable not set")
+        sys.exit(1)
+
+    logger.info(f"Fetching webmentions for domain: {domain}")
+
+    try:
+        # Load existing data
+        existing_webmentions = load_existing_webmentions()
+
+        # Get last fetch time for incremental updates
+        since = get_last_fetch_time(existing_webmentions)
+
+        # Fetch new mentions
+        all_mentions = fetch_webmentions(domain, token, since=since)
+
+        if not all_mentions:
+            logger.info("No new mentions found")
+            return
+
+        # Filter to blog-only mentions (exclude social media)
+        blog_mentions = filter_blog_mentions(all_mentions)
+
+        if not blog_mentions:
+            logger.info("No new blog mentions after filtering")
+            return
+
+        # Process and merge with existing data
+        updated_webmentions = process_mentions(blog_mentions, existing_webmentions)
+
+        # Save to file
+        save_webmentions(updated_webmentions)
+
+        logger.info("=" * 60)
+        logger.info("Webmentions fetch completed successfully")
+        logger.info("=" * 60)
+
+    except BotException as e:
+        logger.error(f"Bot error: {e}")
+        sys.exit(1)
+    except Exception as e:
+        logger.exception(f"Unexpected error: {e}")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/config.yaml
+++ b/config.yaml
@@ -59,3 +59,28 @@ web_archive:
   # Automatically submit new article URLs to the Internet Archive (web.archive.org)
   # This creates a permanent snapshot of your content for long-term preservation
   enabled: true
+
+webmentions:
+  # Collect webmentions from blog posts linking to your articles
+  # Uses webmention.io service to track traditional blog mentions
+  # NOTE: Social media mentions (Mastodon, Bluesky) are excluded as they're
+  # already tracked in mappings.json by the social bot
+  enabled: true
+
+  # Excluded social media domains (automatically filtered out)
+  # These are already tracked in mappings.json
+  excluded_domains:
+    - mastodon.social
+    - bsky.app
+    - twitter.com
+    - x.com
+    - threads.net
+    - linkedin.com
+    - facebook.com
+    - instagram.com
+    # Add other Mastodon instances as needed
+    - fosstodon.org
+    - hachyderm.io
+    - mas.to
+    - mstdn.social
+    - infosec.exchange


### PR DESCRIPTION
Implements blog-only webmentions tracking using webmention.io service.
This feature collects traditional blog mentions while excluding social
media platforms (Mastodon, Bluesky) which are already tracked in
mappings.json by the social bot.

Changes:
- Add bots/webmentions/fetch_webmentions.py: Main script to fetch and
  process webmentions from webmention.io API
- Add .github/workflows/fetch-webmentions.yml: Automated workflow that
  runs every 6 hours to collect new mentions
- Update config.yaml: Add webmentions configuration section with
  excluded domains list
- Update README.md: Document webmentions feature and setup instructions
- Add bots/webmentions/README.md: Detailed documentation for setup
  and usage

Features:
- Fetches mentions from webmention.io API every 6 hours
- Filters out social media sources automatically
- Incremental updates (only fetches new mentions since last run)
- Thread-safe file locking for data integrity
- Stores mentions in webmentions.json at repository root
- Auto-commits changes to repository

Setup required:
1. Sign up at webmention.io with your domain
2. Add webmention endpoint to website HTML
3. Configure GitHub secrets: WEBMENTION_IO_TOKEN and BEARBLOG_DOMAIN