### PR TITLE
Add broken link checker bot and GitHub Actions workflow

### DIFF
--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -1,0 +1,94 @@
+name: Broken Link Checker
+
+run-name: ${{ github.event_name == 'workflow_run' && 'Broken link check after backup' || github.event_name == 'schedule' && 'Scheduled broken link check' || 'Manual broken link check' }}
+
+on:
+  workflow_run:
+    workflows: ["Backup Bot"]
+    types: [completed]
+  schedule:
+    - cron: '0 3 * * 1'  # Every Monday at 03:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: link-checker
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Dependencies
+        run: pip install -r bots/link_checker/requirements.txt
+
+      - name: Run Link Checker
+        run: python bots/link_checker/link_checker.py
+
+      - name: Create Issue for Broken Links
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          REPORT_FILE="bots/link_checker/broken_links.json"
+          if [ -f "$REPORT_FILE" ]; then
+            python - <<'PY'
+            import json
+            from datetime import datetime, timezone
+            from pathlib import Path
+
+            report_file = Path("bots/link_checker/broken_links.json")
+            report = json.loads(report_file.read_text(encoding="utf-8"))
+
+            if not report:
+                raise SystemExit(0)
+
+            lines = [
+                "## Broken Links Detected",
+                "",
+                "The following broken links were found in blog posts:",
+                "",
+            ]
+
+            for item in report:
+                article = item.get("article_url", "unknown")
+                link = item.get("link_url", "unknown")
+                status = item.get("status", "unknown")
+                lines.append(f"- **Article:** {article}")
+                lines.append(f"  - Link: {link}")
+                lines.append(f"  - Status: `{status}`")
+                lines.append("")
+
+            lines.extend(
+                [
+                    "### Workflow Run",
+                    f"- **Run ID:** ${{{{ github.run_id }}}}",
+                    f"- **Triggered by:** ${{{{ github.event_name }}}}",
+                    f"- **Timestamp:** {datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}",
+                ]
+            )
+
+            Path("issue_body.md").write_text("\n".join(lines), encoding="utf-8")
+            PY
+
+            if [ -f "issue_body.md" ]; then
+              gh issue create \
+                --title "Broken links detected" \
+                --body-file issue_body.md
+              rm -f issue_body.md "$REPORT_FILE"
+            fi
+          else
+            echo "No broken link report found"
+          fi

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Hey and welcome 👋🏼 This is the powerhouse behind my [Bear Blog](https://be
 - **pings search engines** for faster indexing
 - **archives URLs to the Internet Archive** for long-term preservation
 - and **collects webmentions** from other blogs linking to your articles.
+- plus **checks blog posts for broken links** and opens issues when found.
 
 ## Project Structure
 
@@ -18,6 +19,7 @@ Hey and welcome 👋🏼 This is the powerhouse behind my [Bear Blog](https://be
 │   ├── social_bot/          # Social media posting bot
 │   │   └── config.json      # Feed & template config
 │   ├── backup_bot/          # Bear Blog backup bot
+│   ├── link_checker/        # Broken link checker
 │   └── webmentions/         # Webmentions collection bot
 ├── blog-backup/             # Archived posts (auto-generated)
 └── docs/                    # Documentation
@@ -142,6 +144,32 @@ webmentions:
 ```
 
 → [Full Documentation](bots/webmentions/README.md)
+
+---
+
+### 🧭 Broken Link Checker
+
+Automatically scans your backed up posts for broken links and creates a GitHub Issue with the article URL and failing link.
+
+**How it works:**
+- Parses links from `blog-backup/*/index.md`
+- Checks each external URL (HEAD with GET fallback)
+- Creates a GitHub Issue when broken links are found
+
+**Configuration:**
+```yaml
+link_checker:
+  enabled: true
+  timeout_seconds: 10
+  max_workers: 8
+  user_agent: "bearblog-link-checker/1.0"
+```
+
+**Triggering:**
+- Runs automatically after the Backup Bot
+- Runs weekly via cron
+
+→ [Full Documentation](docs/LINK_CHECKER.md)
 
 ---
 

--- a/bots/link_checker/link_checker.py
+++ b/bots/link_checker/link_checker.py
@@ -1,0 +1,223 @@
+"""
+Broken link checker for Bear Blog backups.
+"""
+
+import json
+import logging
+import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+from urllib.parse import urlparse
+
+import requests
+import yaml
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from shared import CONFIG, create_session, is_safe_url, MAX_WORKERS
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+LINK_CHECKER_CONFIG = CONFIG.get('link_checker', {})
+LINK_CHECKER_ENABLED = LINK_CHECKER_CONFIG.get('enabled', True)
+LINK_TIMEOUT = LINK_CHECKER_CONFIG.get('timeout_seconds', 10)
+MAX_LINK_WORKERS = LINK_CHECKER_CONFIG.get('max_workers', MAX_WORKERS)
+USER_AGENT = LINK_CHECKER_CONFIG.get('user_agent', 'bearblog-link-checker/1.0')
+
+BLOG_CONFIG = CONFIG.get('blog', {})
+BLOG_SITE_URL = BLOG_CONFIG.get('site_url', '').strip()
+BACKUP_FOLDER = CONFIG.get('backup', {}).get('folder', 'blog-backup')
+
+REPORT_FILE = Path(__file__).parent / 'broken_links.json'
+
+MARKDOWN_LINK_RE = re.compile(r'!?\[[^\]]*]\(([^)]+)\)')
+AUTOLINK_RE = re.compile(r'<(https?://[^>]+)>')
+BARE_URL_RE = re.compile(r'(https?://[^\s<>\[\]{}"\'`]+)')
+FENCED_CODE_RE = re.compile(r'```.*?```', re.DOTALL)
+
+TRAILING_PUNCTUATION = '.,:;!?)]}\'"'
+
+
+@dataclass(frozen=True)
+class LinkIssue:
+    article_url: str
+    link_url: str
+    status: str
+    file_path: str
+
+
+def strip_frontmatter(text: str) -> Tuple[Dict, str]:
+    if text.startswith('---'):
+        parts = text.split('---', 2)
+        if len(parts) >= 3:
+            frontmatter = yaml.safe_load(parts[1]) or {}
+            return frontmatter, parts[2]
+    return {}, text
+
+
+def normalize_url(url: str) -> str:
+    url = url.strip().strip('<>').strip()
+    return url.rstrip(TRAILING_PUNCTUATION)
+
+
+def extract_links(markdown: str) -> Set[str]:
+    cleaned = FENCED_CODE_RE.sub('', markdown)
+    urls: Set[str] = set()
+
+    for match in MARKDOWN_LINK_RE.findall(cleaned):
+        url = normalize_url(match.split()[0])
+        if url:
+            urls.add(url)
+
+    for match in AUTOLINK_RE.findall(cleaned):
+        url = normalize_url(match)
+        if url:
+            urls.add(url)
+
+    for match in BARE_URL_RE.findall(cleaned):
+        url = normalize_url(match)
+        if url:
+            urls.add(url)
+
+    return urls
+
+
+def build_article_url(frontmatter: Dict) -> str:
+    canonical = (frontmatter.get('canonical_url') or '').strip()
+    if canonical:
+        return canonical
+
+    alias = (frontmatter.get('alias') or '').strip()
+    slug = (frontmatter.get('slug') or '').strip()
+    path = alias or slug
+
+    if not BLOG_SITE_URL:
+        return path or 'unknown'
+
+    if path:
+        return f"{BLOG_SITE_URL.rstrip('/')}/{path.lstrip('/')}"
+
+    return BLOG_SITE_URL
+
+
+def find_markdown_files() -> Iterable[Path]:
+    backup_path = Path(BACKUP_FOLDER)
+    return sorted(backup_path.glob('*/index.md'))
+
+
+def check_link(session: requests.Session, url: str) -> Optional[str]:
+    try:
+        if not is_safe_url(url):
+            return 'invalid_url'
+
+        head_response = session.head(url, allow_redirects=True, timeout=LINK_TIMEOUT)
+        status_code = head_response.status_code
+        if status_code in {405}:
+            head_response.close()
+            get_response = session.get(url, allow_redirects=True, timeout=LINK_TIMEOUT, stream=True)
+            status_code = get_response.status_code
+            get_response.close()
+
+        if status_code >= 400:
+            return f'http_{status_code}'
+
+        return None
+    except requests.RequestException as exc:
+        return f'error_{exc.__class__.__name__}'
+
+
+def collect_links() -> Dict[str, Dict[str, Set[str]]]:
+    link_map: Dict[str, Dict[str, Set[str]]] = {}
+    for markdown_file in find_markdown_files():
+        content = markdown_file.read_text(encoding='utf-8')
+        frontmatter, body = strip_frontmatter(content)
+        article_url = build_article_url(frontmatter)
+        links = extract_links(body)
+
+        for link in links:
+            if not link.startswith(('http://', 'https://')):
+                continue
+            if link not in link_map:
+                link_map[link] = {"articles": set(), "files": set()}
+            link_map[link]["articles"].add(article_url)
+            link_map[link]["files"].add(str(markdown_file))
+
+    return link_map
+
+
+def run_link_checks(link_map: Dict[str, Dict[str, Set[str]]]) -> List[LinkIssue]:
+    if not link_map:
+        return []
+
+    session = create_session(USER_AGENT)
+    issues: List[LinkIssue] = []
+
+    with ThreadPoolExecutor(max_workers=MAX_LINK_WORKERS) as executor:
+        future_map = {
+            executor.submit(check_link, session, url): url
+            for url in link_map.keys()
+        }
+
+        for future in as_completed(future_map):
+            url = future_map[future]
+            status = future.result()
+            if status:
+                for article_url in link_map[url]["articles"]:
+                    for file_path in link_map[url]["files"]:
+                        issues.append(
+                            LinkIssue(
+                                article_url=article_url,
+                                link_url=url,
+                                status=status,
+                                file_path=file_path,
+                            )
+                        )
+
+    return issues
+
+
+def save_report(issues: List[LinkIssue]) -> None:
+    report_data = [
+        {
+            "article_url": issue.article_url,
+            "link_url": issue.link_url,
+            "status": issue.status,
+            "file_path": issue.file_path,
+        }
+        for issue in issues
+    ]
+
+    if report_data:
+        with open(REPORT_FILE, 'w', encoding='utf-8') as f:
+            json.dump(report_data, f, indent=2, ensure_ascii=False)
+        logger.info(f"Saved broken link report to {REPORT_FILE}")
+    else:
+        if REPORT_FILE.exists():
+            REPORT_FILE.unlink()
+        logger.info("No broken links found")
+
+
+def main() -> None:
+    if not LINK_CHECKER_ENABLED:
+        logger.info("Link checker disabled via config")
+        return
+
+    logger.info("Collecting links from blog backups...")
+    link_map = collect_links()
+    logger.info("Checking %s unique links", len(link_map))
+
+    issues = run_link_checks(link_map)
+    logger.info("Broken links found: %s", len(issues))
+    save_report(issues)
+
+
+if __name__ == '__main__':
+    main()

--- a/bots/link_checker/requirements.txt
+++ b/bots/link_checker/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31.0
+PyYAML>=6.0

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,8 @@
 blog:
   # Your Bear Blog username (used for backup export URL)
   bearblog_username: "fischr"
+  # Public base URL for your blog (used for link checker reports)
+  site_url: "https://fischr.org"
 
 backup:
   # Directory name for blog post backups (relative to repository root)
@@ -84,3 +86,13 @@ webmentions:
     - mas.to
     - mstdn.social
     - infosec.exchange
+
+link_checker:
+  # Enable the broken link checker
+  enabled: true
+  # HTTP timeout per link (seconds)
+  timeout_seconds: 10
+  # Concurrent link checks
+  max_workers: 8
+  # User-Agent used for link checks
+  user_agent: "bearblog-link-checker/1.0"

--- a/docs/LINK_CHECKER.md
+++ b/docs/LINK_CHECKER.md
@@ -1,0 +1,53 @@
+# Broken Link Checker
+
+The Broken Link Checker scans your backed-up posts for broken links and opens a GitHub Issue when it finds any.
+
+---
+
+## How It Works
+
+1. Loads all `blog-backup/*/index.md` files
+2. Extracts external HTTP/HTTPS links
+3. Checks each unique link (HEAD with GET fallback)
+4. Writes a report to `bots/link_checker/broken_links.json`
+5. The workflow creates a GitHub Issue and deletes the report file
+
+---
+
+## Configuration
+
+Add the following section to `config.yaml`:
+
+```yaml
+blog:
+  site_url: "https://your-domain.com"
+
+link_checker:
+  enabled: true
+  timeout_seconds: 10
+  max_workers: 8
+  user_agent: "bearblog-link-checker/1.0"
+```
+
+`blog.site_url` is used to build article URLs when no canonical URL is set in the frontmatter.
+
+---
+
+## Workflow
+
+The checker runs in two cases:
+
+- **After Backup Bot** (`workflow_run`)
+- **Weekly** via cron (every Monday at 03:00 UTC)
+
+You can also run it manually from GitHub Actions.
+
+---
+
+## Output
+
+When broken links are found, a GitHub Issue is created with:
+
+- Article URL
+- Broken link URL
+- Status (HTTP status or timeout/error)


### PR DESCRIPTION
### Motivation
- Add automated detection of broken external links in backed-up blog posts to surface issues for manual fixing.
- Run the checker after backups and on a weekly schedule so issues are found soon after content changes.
- Provide configurable timeouts, concurrency and a `site_url` to build article links when frontmatter lacks a canonical URL.

### Description
- Adds a new link checker implementation at `bots/link_checker/link_checker.py` that parses `blog-backup/*/index.md`, extracts external links, runs HEAD (with GET fallback) checks, and writes `bots/link_checker/broken_links.json` for failures.
- Adds a workflow `.github/workflows/link_checker.yml` that runs after the Backup Bot, weekly via cron, and creates a GitHub Issue when broken links are reported.
- Adds `bots/link_checker/requirements.txt`, documentation `docs/LINK_CHECKER.md`, and updates `README.md` to describe the feature.
- Adds configuration defaults in `config.yaml` (`blog.site_url` and `link_checker` section with `enabled`, `timeout_seconds`, `max_workers`, and `user_agent`).

### Testing
- No automated tests were executed as part of this change.
- The new files were added and committed successfully (`git commit` completed without error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696034bea3c48328ab52556804a906d5)