### PR TITLE
Handle non-string frontmatter values in link checker

### DIFF
--- a/bots/link_checker/link_checker.py
+++ b/bots/link_checker/link_checker.py
@@ -91,12 +91,17 @@ def extract_links(markdown: str) -> Set[str]:
 
 
 def build_article_url(frontmatter: Dict) -> str:
-    canonical = (frontmatter.get('canonical_url') or '').strip()
+    def clean_frontmatter_value(value: object) -> str:
+        if value is None:
+            return ''
+        return str(value).strip()
+
+    canonical = clean_frontmatter_value(frontmatter.get('canonical_url'))
     if canonical:
         return canonical
 
-    alias = (frontmatter.get('alias') or '').strip()
-    slug = (frontmatter.get('slug') or '').strip()
+    alias = clean_frontmatter_value(frontmatter.get('alias'))
+    slug = clean_frontmatter_value(frontmatter.get('slug'))
     path = alias or slug
 
     if not BLOG_SITE_URL:


### PR DESCRIPTION
### Motivation
- The link checker crashed with an `AttributeError` when frontmatter fields like `slug` were non-string (e.g., integers) because the code called `.strip()` directly on the value. 
- Make `build_article_url` robust against non-string or missing frontmatter values so the checker can run on a variety of backups. 

### Description
- Added a helper function `clean_frontmatter_value` in `bots/link_checker/link_checker.py` to coerce frontmatter values to strings and trim whitespace. 
- Replaced direct `.strip()` calls with `clean_frontmatter_value` for `canonical_url`, `alias`, and `slug` inside `build_article_url`. 
- Kept existing URL-building logic intact so behavior is unchanged for normal string frontmatter values. 

### Testing
- No automated tests were executed against the modified code after this change. 
- Note: a prior workflow run failed with an automated execution error when running `python bots/link_checker/link_checker.py` due to the `AttributeError` that this change addresses.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69603c6502c88328a459ea083d8bbcb6)