### PR TITLE
Debug link checker breaking issue

### DIFF
--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -84,7 +84,7 @@ jobs:
             )
 
             Path("issue_body.md").write_text("\n".join(lines), encoding="utf-8")
-            PY
+PY
 
             if [ -f "issue_body.md" ]; then
               gh issue create \


### PR DESCRIPTION
The PY delimiter must be at the start of the line without indentation for bash heredoc to work correctly.