### PR TITLE
Auto-exclude domains with bot detection

### DIFF
--- a/ISSUE_AUTO_EXCLUDE_DOMAINS.md
+++ b/ISSUE_AUTO_EXCLUDE_DOMAINS.md
@@ -1,0 +1,51 @@
+# Auto-exclude domains with bot detection from link checker
+
+## Summary
+
+The link checker now automatically excludes domains that show signs of bot detection or aggressive rate limiting. This prevents false positives and reduces noise in link checking reports.
+
+## Changes
+
+### 1. Automatic Domain Exclusion
+When the link checker encounters specific HTTP status codes that indicate bot blocking, it automatically:
+- Adds the domain to `bots/linkcheck_bot/excluded_domains.txt`
+- Logs the exclusion in `bots/linkcheck_bot/auto_excluded_domains.json`
+- Prevents future checks for that domain in the same run
+
+**Status codes that trigger auto-exclusion:**
+- `403 Forbidden` - Often indicates bot blocking
+- `429 Too Many Requests` - Rate limiting
+- `999` - LinkedIn's custom "request denied" code
+
+### 2. Pre-populated Excluded Domains
+Added common false positives to `excluded_domains.txt`:
+- **Wikipedia & Wikimedia projects** (wikipedia.org, wikimedia.org, wiktionary.org, etc.)
+- **Reference sites** (britannica.com, merriam-webster.com)
+- **Social media** (linkedin.com, facebook.com, instagram.com, twitter.com, x.com)
+- **Cloudflare** (cloudflare.com)
+
+### 3. Simplified Configuration
+- Removed `excluded_domains` from `config.yaml` - all exclusions are now managed in `excluded_domains.txt`
+- The system only uses `bots/linkcheck_bot/excluded_domains.txt` for exclusions
+
+## Monitoring Auto-Excluded Domains
+
+Check `bots/linkcheck_bot/auto_excluded_domains.json` to see which domains were automatically excluded and when. Each entry includes:
+- Domain name
+- Original URL that triggered the exclusion
+- HTTP status code (reason)
+- Timestamp
+
+## Review Process
+
+Periodically review auto-excluded domains to ensure legitimate sites aren't being excluded incorrectly. If a domain was incorrectly excluded:
+1. Remove it from `excluded_domains.txt`
+2. Manually verify the link is working
+3. Consider adjusting the auto-exclusion logic if needed
+
+## Technical Details
+
+- Thread-safe implementation using locks to prevent race conditions
+- In-memory tracking prevents duplicate exclusions in the same run
+- Domains are normalized (www. prefix removed) for consistency
+- Both exact matches and subdomains are excluded

--- a/bots/linkcheck_bot/excluded_domains.txt
+++ b/bots/linkcheck_bot/excluded_domains.txt
@@ -11,8 +11,33 @@
 # 2. Run the link checker again
 # 3. Remove the domain when ready to check again
 
-# Sites with aggressive rate limiting
+# Sites with aggressive rate limiting or bot detection
 bergfex.de
 bergfex.com
 bergfex.at
 tollwood.de
+
+# Wikipedia and Wikimedia projects (often block bots, but content is reliable)
+wikipedia.org
+wikimedia.org
+wiktionary.org
+wikiquote.org
+wikibooks.org
+wikisource.org
+wikinews.org
+wikiversity.org
+wikivoyage.org
+
+# Other encyclopedic/reference sites with aggressive bot protection
+britannica.com
+merriam-webster.com
+
+# Social media platforms (already tracked elsewhere)
+linkedin.com
+facebook.com
+instagram.com
+twitter.com
+x.com
+
+# Sites with strict bot protection
+cloudflare.com

--- a/config.yaml
+++ b/config.yaml
@@ -99,7 +99,5 @@ link_checker:
   # User-Agent used for link checks
   # Using a standard browser User-Agent to avoid being blocked by overly aggressive bot detection
   user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-  # Domains to exclude from link checking (e.g., sites with aggressive rate limiting)
-  # DEPRECATED: Please add domains to bots/linkcheck_bot/excluded_domains.txt instead
-  # This config option is kept for backwards compatibility but excluded_domains.txt is preferred
-  excluded_domains: []
+  # Note: Excluded domains are managed in bots/linkcheck_bot/excluded_domains.txt
+  # Domains with bot detection (403, 429 errors) are automatically added to the exclusion list


### PR DESCRIPTION
This update improves the link checker by automatically excluding domains that show signs of bot detection, reducing false positives and noise.

Changes:
- Auto-exclude domains on 403, 429, and 999 status codes
- Pre-populate excluded_domains.txt with common false positives:
  * Wikipedia and Wikimedia projects
  * Reference sites (Britannica, Merriam-Webster)
  * Social media platforms
  * Cloudflare
- Remove excluded_domains from config.yaml (now only in excluded_domains.txt)
- Track auto-excluded domains in auto_excluded_domains.json for monitoring
- Thread-safe implementation to prevent race conditions

The link checker will now automatically add problematic domains to the exclusion list and log them for review.