### PR TITLE
Add GitHub issue notifications for new webmentions

### DIFF
--- a/.github/workflows/fetch-webmentions.yml
+++ b/.github/workflows/fetch-webmentions.yml
@@ -14,6 +14,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   fetch-webmentions:
@@ -67,4 +68,27 @@ jobs:
             fi
           else
             echo "No webmentions.json file generated"
+          fi
+
+      - name: Create GitHub Issue for New Webmentions
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          REPORT_FILE="bots/webmentions_bot/new_mentions.json"
+
+          if [ -f "$REPORT_FILE" ]; then
+            python bots/webmentions_bot/create_issue_body.py
+
+            if [ -f "bots/webmentions_bot/issue_body.md" ]; then
+              MENTION_COUNT=$(jq 'length' "$REPORT_FILE")
+
+              gh issue create \
+                --title "New Webmentions: $MENTION_COUNT new mention(s) received" \
+                --body-file bots/webmentions_bot/issue_body.md
+
+              rm -f bots/webmentions_bot/issue_body.md "$REPORT_FILE"
+            fi
+          else
+            echo "No new mentions to report"
           fi

--- a/bots/webmentions_bot/create_issue_body.py
+++ b/bots/webmentions_bot/create_issue_body.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Create GitHub issue body for new webmentions notifications.
+"""
+
+import json
+import sys
+from pathlib import Path
+from datetime import datetime
+
+REPORT_FILE = Path(__file__).parent / "new_mentions.json"
+OUTPUT_FILE = Path(__file__).parent / "issue_body.md"
+
+
+def create_issue_body():
+    """Create formatted issue body from new mentions report."""
+    if not REPORT_FILE.exists():
+        print("No new mentions report found")
+        sys.exit(0)
+
+    try:
+        with open(REPORT_FILE, 'r', encoding='utf-8') as f:
+            new_mentions = json.load(f)
+    except Exception as e:
+        print(f"Error reading report: {e}")
+        sys.exit(1)
+
+    if not new_mentions:
+        print("No new mentions in report")
+        sys.exit(0)
+
+    mention_count = len(new_mentions)
+
+    # Build issue body
+    lines = [
+        "## New Webmentions Received",
+        "",
+        f"You have **{mention_count}** new webmention(s) from other blogs! 🎉",
+        ""
+    ]
+
+    for i, mention in enumerate(new_mentions, 1):
+        lines.append("---")
+        lines.append("")
+        lines.append(f"### Mention {i}")
+        lines.append("")
+
+        # Author
+        author_name = mention.get('author', {}).get('name', 'Unknown')
+        author_url = mention.get('author', {}).get('url', '')
+
+        if author_url:
+            lines.append(f"**From:** {author_name} ([{author_url}]({author_url}))")
+        else:
+            lines.append(f"**From:** {author_name}")
+
+        # Source and target
+        source = mention.get('source', 'Unknown')
+        target = mention.get('target', 'Unknown')
+        lines.append(f"**Source:** {source}")
+        lines.append(f"**Your Article:** {target}")
+
+        # Optional fields
+        title = mention.get('title', '')
+        if title:
+            lines.append(f"**Title:** {title}")
+
+        published = mention.get('published', '')
+        if published:
+            try:
+                # Try to format the date nicely
+                dt = datetime.fromisoformat(published.replace('Z', '+00:00'))
+                formatted_date = dt.strftime('%Y-%m-%d %H:%M UTC')
+                lines.append(f"**Published:** {formatted_date}")
+            except:
+                lines.append(f"**Published:** {published}")
+
+        content = mention.get('content', '')
+        if content:
+            lines.append("")
+            lines.append("**Excerpt:**")
+            lines.append(f"> {content}")
+
+        lines.append("")
+
+    # Footer
+    lines.extend([
+        "---",
+        "",
+        "View all webmentions in the [`webmentions.json`](../../webmentions.json) file in the repository.",
+        "",
+        "**Tip:** You can disable these notifications by setting `notify_on_new_mentions: false` in `config.yaml`.",
+        ""
+    ])
+
+    # Write to output file
+    try:
+        with open(OUTPUT_FILE, 'w', encoding='utf-8') as f:
+            f.write('\n'.join(lines))
+        print(f"Created issue body with {mention_count} mention(s)")
+    except Exception as e:
+        print(f"Error writing issue body: {e}")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    create_issue_body()

--- a/config.yaml
+++ b/config.yaml
@@ -69,6 +69,10 @@ webmentions:
   # already tracked in mappings.json by the social bot
   enabled: true
 
+  # Create GitHub issue when new webmentions are received
+  # This sends a notification for each batch of new mentions
+  notify_on_new_mentions: true
+
   # Excluded social media domains (automatically filtered out)
   # These are already tracked in mappings.json
   excluded_domains:


### PR DESCRIPTION
Implements configurable notifications when new webmentions are received:

- Add notify_on_new_mentions config option to config.yaml (default: true)
- Extend fetch_webmentions.py to track new mentions and create report
- Add create_issue_body.py to format webmention notifications
- Update workflow to create GitHub issues with mention details

When enabled, the bot will create a GitHub issue for each batch of new
webmentions, including author info, source URL, target article, and excerpt.

Users can disable notifications by setting notify_on_new_mentions: false
in config.yaml.