### PR TITLE
Query webmention.io by domain to include article-level mentions

### DIFF
--- a/bots/webmentions_bot/fetch_webmentions.py
+++ b/bots/webmentions_bot/fetch_webmentions.py
@@ -97,7 +97,7 @@ def fetch_webmentions(domain: str, token: str, since: str = None) -> List[Dict]:
         List of webmention objects
     """
     params = {
-        'target': f'https://{domain}/',
+        'domain': domain,
         'token': token,
         'per-page': 100  # Max allowed by webmention.io
     }


### PR DESCRIPTION
### Motivation
- The fetcher used `target: https://{domain}/` which only requested the homepage and missed webmentions that point to individual article URLs, so those mentions were not saved to `webmentions.json`.

### Description
- Update `bots/webmentions_bot/fetch_webmentions.py` to send `domain` (instead of `target`) in the API `params` so webmention.io returns mentions for the entire domain and article-level backlinks are collected.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c9e02f8f88328ab4ebe4a833db399)