### PR TITLE
Prevent duplicate social posts by including mappings.json in posted cache

### DIFF
--- a/bots/social_bot/social_bot.py
+++ b/bots/social_bot/social_bot.py
@@ -953,7 +953,16 @@ def run() -> None:
         validate_credentials(config)
 
         posted_cache = load_posted_articles()
-        logger.info(f"Loaded {len(posted_cache)} previously posted articles")
+        posted_file_count = len(posted_cache)
+        social_mappings = load_social_mappings()
+        if social_mappings:
+            posted_cache.update(social_mappings.keys())
+        logger.info(
+            "Loaded %s previously posted articles (%s from posted file, %s from mappings)",
+            len(posted_cache),
+            posted_file_count,
+            len(social_mappings)
+        )
 
         # Load max article age setting (0 = no limit)
         max_article_age_days = CONFIG.get('social', {}).get('max_article_age_days', 0)


### PR DESCRIPTION
### Motivation
- Prevent accidental re-posting when `posted_articles.txt` failed to be updated by treating existing `mappings.json` entries as already-posted sources. 

### Description
- Load `mappings.json` via `load_social_mappings()` during startup and merge its keys into the in-memory posted cache so entries already recorded in mappings are skipped; also log counts from the posted file and mappings. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c9eaa99008328917e9a26bfaa81a3)