### PR TITLE
Fix retry-queue imports, make workflow rebase conflict-tolerant, and include mappings in posted cache

### DIFF
--- a/.github/workflows/social_bot.yml
+++ b/.github/workflows/social_bot.yml
@@ -226,7 +226,10 @@ jobs:
           if git commit -m "Update posted articles and feed cache"; then
             echo "changes=true" >> $GITHUB_OUTPUT
             # Pull latest changes before pushing to avoid conflicts with parallel workflows
-            git pull --rebase origin main
+            if ! git pull --rebase --autostash origin main; then
+              git rebase --abort || true
+              git pull --rebase --autostash -X ours origin main
+            fi
             git push
           else
             echo "changes=false" >> $GITHUB_OUTPUT

--- a/bots/social_bot/retry_queue.py
+++ b/bots/social_bot/retry_queue.py
@@ -178,7 +178,7 @@ class RetryQueue:
             failed_platforms: List of dicts with 'platform' and 'error' keys
             successful_platforms: List of platforms that succeeded
         """
-        from bots.shared import FileLock
+        from shared import FileLock
 
         with FileLock(self.lock_file):
             queue = self._load_queue()
@@ -244,7 +244,7 @@ class RetryQueue:
         Returns:
             List of RetryQueueEntry objects ready for retry
         """
-        from bots.shared import FileLock
+        from shared import FileLock
 
         with FileLock(self.lock_file):
             queue = self._load_queue()

--- a/bots/social_bot/social_bot.py
+++ b/bots/social_bot/social_bot.py
@@ -953,7 +953,16 @@ def run() -> None:
         validate_credentials(config)
 
         posted_cache = load_posted_articles()
-        logger.info(f"Loaded {len(posted_cache)} previously posted articles")
+        posted_file_count = len(posted_cache)
+        social_mappings = load_social_mappings()
+        if social_mappings:
+            posted_cache.update(social_mappings.keys())
+        logger.info(
+            "Loaded %s previously posted articles (%s from posted file, %s from mappings)",
+            len(posted_cache),
+            posted_file_count,
+            len(social_mappings)
+        )
 
         # Load max article age setting (0 = no limit)
         max_article_age_days = CONFIG.get('social', {}).get('max_article_age_days', 0)


### PR DESCRIPTION
### Motivation
- Prevent the retry-queue job from crashing with `ModuleNotFoundError` due to incorrect package imports used by the Actions runner. 
- Avoid workflow failures when the `git pull --rebase` step encounters merge conflicts on state files like `mappings.json`. 
- Ensure articles already recorded in `mappings.json` are treated as posted to reduce accidental duplicate posting. 

### Description
- Change internal imports in `bots/social_bot/retry_queue.py` from `from bots.shared import FileLock` to `from shared import FileLock` so `process_retry_queue.py` can import the module under the runner `PYTHONPATH`. 
- Make the workflow pull step in `.github/workflows/social_bot.yml` more robust by using `git pull --rebase --autostash` and falling back to aborting the failed rebase and retrying with `-X ours` to tolerate JSON/state merge conflicts. 
- Merge social mapping keys into the in-memory posted cache in `bots/social_bot/social_bot.py` (via `load_social_mappings()`), and log counts from both the posted file and mappings when the bot starts. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c9eaa99008328917e9a26bfaa81a3)