### PR TITLE
Queue social bot runs and fix retry queue imports

### DIFF
--- a/.github/workflows/social_bot.yml
+++ b/.github/workflows/social_bot.yml
@@ -10,11 +10,11 @@ on:
     types: [rss_feed_update]
 
 # Ensure only one instance runs at a time to prevent duplicate posts
-# cancel-in-progress: true queues concurrent runs instead of running in parallel
-# This prevents race conditions that could cause duplicate posts
+# cancel-in-progress: false queues concurrent runs instead of canceling in-flight runs
+# This prevents race conditions that could cause duplicate posts without sending cancel emails
 concurrency:
   group: social-bot
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write

--- a/bots/social_bot/retry_queue.py
+++ b/bots/social_bot/retry_queue.py
@@ -280,7 +280,7 @@ class RetryQueue:
             still_failed_platforms: Platforms that still failed
             newly_succeeded_platforms: Platforms that succeeded this time
         """
-        from bots.shared import FileLock
+        from shared import FileLock
 
         with FileLock(self.lock_file):
             queue = self._load_queue()
@@ -350,7 +350,7 @@ class RetryQueue:
 
     def remove_from_queue(self, article_url: str) -> None:
         """Remove an entry from the queue."""
-        from bots.shared import FileLock
+        from shared import FileLock
 
         with FileLock(self.lock_file):
             queue = self._load_queue()
@@ -367,7 +367,7 @@ class RetryQueue:
         Returns:
             List of RetryQueueEntry objects that have exhausted retries
         """
-        from bots.shared import FileLock
+        from shared import FileLock
 
         with FileLock(self.lock_file):
             queue = self._load_queue()
@@ -392,7 +392,7 @@ class RetryQueue:
         Returns:
             Number of entries removed
         """
-        from bots.shared import FileLock
+        from shared import FileLock
 
         with FileLock(self.lock_file):
             queue = self._load_queue()
@@ -412,7 +412,7 @@ class RetryQueue:
 
     def get_stats(self) -> Dict[str, Any]:
         """Get statistics about the retry queue."""
-        from bots.shared import FileLock
+        from shared import FileLock
 
         with FileLock(self.lock_file):
             queue = self._load_queue()


### PR DESCRIPTION
### Motivation
- Prevent in-flight `social_bot` runs from being canceled when new triggers arrive to avoid spurious "operation canceled" jobs and notification emails.
- Fix a Python import error causing `ModuleNotFoundError: No module named 'bots'` in the retry queue logic so the retry processor can run reliably.

### Description
- Change workflow concurrency in `.github/workflows/social_bot.yml` to queue new runs instead of canceling in-progress runs by setting `cancel-in-progress: false` and update the explanatory comment.
- Replace incorrect imports in `bots/social_bot/retry_queue.py` by using `from shared import FileLock` instead of `from bots.shared import FileLock` in all affected functions.
- Commit message: `Prevent social bot cancellations and fix retry imports`.

### Testing
- No automated tests were run as part of this change (CI was not triggered for these edits).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dd58aff348328a713e9634c44c178)