### PR TITLE
Ensure Internet Archive submissions: use POST in social bot and submit new backups

### DIFF
--- a/bots/social_bot/social_bot.py
+++ b/bots/social_bot/social_bot.py
@@ -422,11 +422,10 @@ def submit_to_web_archive(url: str) -> None:
 
     try:
         # Internet Archive Save Page Now API endpoint
-        # Using the simple GET method which doesn't require authentication
-        archive_url = f"https://web.archive.org/save/{url}"
-
-        response = session.get(
-            archive_url,
+        # Using POST with url param for improved compatibility
+        response = session.post(
+            "https://web.archive.org/save",
+            data={"url": url},
             timeout=REQUEST_TIMEOUT,
             allow_redirects=True
         )


### PR DESCRIPTION
### Motivation
- New articles were not being archived to archive.org reliably, and the social bot's GET-based Save Page Now calls can be incompatible with the current Archive.org endpoint.  
- Backup processing did not attempt archival, so posts that never get social-posted were missed by the archive workflow.  

### Description
- Switch the social bot `submit_to_web_archive` to use `POST` to `https://web.archive.org/save` with `data={'url': url}` for improved compatibility.  
- Add `SITE_URL` config usage and a `build_article_url(row)` helper in the backup bot to construct a public article URL from `canonical url` or `slug`.  
- Add `submit_to_web_archive(url)` to the backup bot and invoke it for articles processed as `new` or `updated`, respecting `web_archive.enabled` in `config.yaml`.  
- Log a warning when a public URL cannot be built and skip archival in that case; reuse the existing shared `session` and `REQUEST_TIMEOUT` behavior.  

### Testing
- No automated tests or CI runs were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dd758f75c83289356fc38284a561a)