### PR TITLE
Exclude chaos.social from webmentions

### DIFF
--- a/bots/webmentions_bot/fetch_webmentions.py
+++ b/bots/webmentions_bot/fetch_webmentions.py
@@ -32,6 +32,7 @@ NEW_MENTIONS_REPORT = Path(__file__).parent / "new_mentions.json"
 # Social media domains to exclude (already tracked in mappings.json)
 EXCLUDED_SOCIAL_DOMAINS = {
     'mastodon.social',
+    'chaos.social',
     'bsky.app',
     'twitter.com',
     'x.com',

--- a/config.yaml
+++ b/config.yaml
@@ -77,6 +77,7 @@ webmentions:
   # These are already tracked in mappings.json
   excluded_domains:
     - mastodon.social
+    - chaos.social
     - bsky.app
     - twitter.com
     - x.com

--- a/docs/WEBMENTIONS_BOT.md
+++ b/docs/WEBMENTIONS_BOT.md
@@ -104,6 +104,7 @@ webmentions:
   enabled: true
   excluded_domains:
     - mastodon.social
+    - chaos.social
     - bsky.app
     # Add more domains as needed
 ```


### PR DESCRIPTION
### Motivation
- Prevent webmentions originating from the `chaos.social` Mastodon instance from being treated as traditional blog webmentions so social mentions are not displayed or double-tracked.

### Description
- Added `chaos.social` to the `webmentions.excluded_domains` list in `config.yaml` so it is part of the configured exclusion set.
- Added `'chaos.social'` to the `EXCLUDED_SOCIAL_DOMAINS` set in `bots/webmentions_bot/fetch_webmentions.py` so the fetcher will skip mentions from that domain.
- Updated `docs/WEBMENTIONS_BOT.md` to document `chaos.social` in the example excluded domains list.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a46d965e483288698d7151422a55e)